### PR TITLE
Fixed reference to the wrong file name

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 
-    <!-- Nothin to see here! Check out index.js-->
+    <!-- Nothin to see here! Check out index.browser.js -->
 
 </body>
 </html>


### PR DESCRIPTION
The example says to look at `index.js` but it should say `index.browser.js`.